### PR TITLE
HM4-01_SolicitarVisitaPadrino

### DIFF
--- a/src/main/java/com/hopematch/hopematch_backend/controllers/VisitaController.java
+++ b/src/main/java/com/hopematch/hopematch_backend/controllers/VisitaController.java
@@ -1,0 +1,53 @@
+package com.hopematch.hopematch_backend.controllers;
+
+import com.hopematch.hopematch_backend.models.Visita;
+import com.hopematch.hopematch_backend.models.Padrino;
+import com.hopematch.hopematch_backend.models.Encargado;
+import com.hopematch.hopematch_backend.services.PadrinoService;
+import com.hopematch.hopematch_backend.services.EncargadoService;
+import com.hopematch.hopematch_backend.services.VisitaService;
+import com.hopematch.hopematch_backend.utils.JwtUtil;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/visitas")
+@CrossOrigin(origins = {"http://localhost:4200", "https://adrianrojas4414.github.io"})
+public class VisitaController {
+
+    @Autowired
+    private VisitaService visitaService;
+
+    @Autowired
+    private PadrinoService padrinoService;
+
+    @Autowired
+    private EncargadoService encargadoService;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @PostMapping("/agendar")
+    public ResponseEntity<String> agendarVisita(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestBody Visita visita) {
+
+        String token = authHeader.replace("Bearer ", "");
+        int idPadrino = jwtUtil.extractId(token);
+
+        Padrino padrino = padrinoService.getPadrinoById(idPadrino)
+                .orElseThrow(() -> new RuntimeException("Padrino no encontrado"));
+
+        Encargado encargado = encargadoService.getFirstEncargado();
+
+        visita.setPadrino(padrino);
+        visita.setEncargado(encargado);
+        visita.setEsperandoRespuesta(true);
+
+        visitaService.saveVisita(visita);
+
+        return ResponseEntity.ok("Visita agendada correctamente.");
+    }
+}

--- a/src/main/java/com/hopematch/hopematch_backend/models/Visita.java
+++ b/src/main/java/com/hopematch/hopematch_backend/models/Visita.java
@@ -1,0 +1,32 @@
+package com.hopematch.hopematch_backend.models;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "visitas_db")
+public class Visita {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "padrino_id", nullable = false)
+    private Padrino padrino;
+
+    @ManyToOne
+    @JoinColumn(name = "encargado_id", nullable = false)
+    private Encargado encargado;
+
+    @Column(name = "fecha_hora", nullable = false)
+    private LocalDateTime fechaHora;
+
+    @Column(name = "esperando_respuesta", nullable = false)
+    private boolean esperandoRespuesta = true;
+}

--- a/src/main/java/com/hopematch/hopematch_backend/repositories/VisitaRepository.java
+++ b/src/main/java/com/hopematch/hopematch_backend/repositories/VisitaRepository.java
@@ -1,0 +1,9 @@
+package com.hopematch.hopematch_backend.repositories;
+
+import com.hopematch.hopematch_backend.models.Visita;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VisitaRepository extends JpaRepository<Visita, Integer> {
+}

--- a/src/main/java/com/hopematch/hopematch_backend/services/EncargadoService.java
+++ b/src/main/java/com/hopematch/hopematch_backend/services/EncargadoService.java
@@ -74,4 +74,11 @@ public class EncargadoService {
             throw new RuntimeException("Encargado con ID " + id + " no encontrado.");
         }
     }
+
+    public Encargado getFirstEncargado() {
+        return encargadoRepository.findAll()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No hay encargados disponibles"));
+    }
 }

--- a/src/main/java/com/hopematch/hopematch_backend/services/VisitaService.java
+++ b/src/main/java/com/hopematch/hopematch_backend/services/VisitaService.java
@@ -1,0 +1,17 @@
+package com.hopematch.hopematch_backend.services;
+
+import com.hopematch.hopematch_backend.models.Visita;
+import com.hopematch.hopematch_backend.repositories.VisitaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VisitaService {
+
+    @Autowired
+    private VisitaRepository visitaRepository;
+
+    public Visita saveVisita(Visita visita) {
+        return visitaRepository.save(visita);
+    }
+}

--- a/src/main/java/com/hopematch/hopematch_backend/utils/JwtUtil.java
+++ b/src/main/java/com/hopematch/hopematch_backend/utils/JwtUtil.java
@@ -51,4 +51,14 @@ public class JwtUtil {
             return false;
         }
     }
+
+    public int extractId(String token) {
+        SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        JwtParser parser = Jwts.parser()
+                .verifyWith(key)
+                .build();
+        return parser.parseSignedClaims(token)
+                .getPayload()
+                .get("id", Integer.class);
+    }
 }


### PR DESCRIPTION
Se crearon implementaciones para agregar funciones en jwt para extraer el id, tambien en encargadoservice se realizo una implementacion. Se agrego la clase Visita, con su respectivo controlador, servicio y repositorio para gestionar las visitas de padrino y encargado.